### PR TITLE
Update grouped-categories.js deepClone function

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -156,9 +156,9 @@ function deepClone(thing) {
     function isArray(obj) {
         return Object.prototype.toString.call(obj) === '[object Array]';
     }
-
-    function isString(obj) {
-        return Object.prototype.toString.call(obj) === '[object String]';
+    
+    function isObject(obj) {
+        return Object.prototype.toString.call(obj) === '[object Object]';
     }
 
     // check for type, array or object
@@ -166,10 +166,10 @@ function deepClone(thing) {
 
     for (key in thing) {
         if (thing.hasOwnProperty(key)) {
-            if (isString(thing[key])) {
-                other[key] = thing[key];
-            } else {
+            if (isObject(thing[key])) {
                 other[key] = deepClone(thing[key]);
+            } else {
+                other[key] = thing[key];
             }           
         }        
     };


### PR DESCRIPTION
(Sorry if this not correct process for contributing on GitHub, feel free to let me know the best way to do this in the future.)
By the way great plugin :+1: 

Updated deepClone function prevent infinite loop when final "category" property is an object.

Previously this function would only complete successfully if the final "category" property was an array of strings.
ie.
xAxis: {
   categories: [{
       name: "1 & 2 Broadgate",
       categories: ['Sub Category 1', 'Sub Category 2']
   }...

This change allow it also to accept objects within final category layer:
xAxis: {
   categories: [{
       name: "Category 1",
       categories: [{ name: "Sub Category 1" }, { name: "Sub Category 2" }]
   }...
