### PR TITLE
Updated bower.json to have 'main'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "highcharts-grouped-categories",
+  "main": "grouped-categories.js",
   "version": "1.1.0",
   "homepage": "http://blacklabel.github.io/grouped_categories/",
   "authors": [


### PR DESCRIPTION
Necessary for bower to work properly with gulp-wiredep as documented here
https://www.npmjs.com/package/wiredep#what-can-go-wrong