### PR TITLE
Add support for reversing a grouped category title on tooltips

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -43,10 +43,11 @@
 		return JSON.parse(JSON.stringify(thing));
 	}
 
-	function Category(obj, parent) {
+	function Category(obj, parent, reverseTooltipTitle) {
 		this.userOptions = deepClone(obj);
 		this.name = obj.name || obj;
 		this.parent = parent;
+		this.reverseTooltipTitle = reverseTooltipTitle;
 
 		return this;
 	}
@@ -58,6 +59,9 @@
 		while (cat) {
 			parts.push(cat.name);
 			cat = cat.parent;
+		}
+		if (this.reverseTooltipTitle) {
+			parts = parts.reverse();
 		}
 
 		return parts.join(', ');
@@ -76,8 +80,8 @@
 	}
 
 	// Adds category leaf to array
-	function addLeaf(out, cat, parent) {
-		out.unshift(new Category(cat, parent));
+	function addLeaf(out, cat, parent, reverseTooltipTitle) {
+		out.unshift(new Category(cat, parent, reverseTooltipTitle));
 
 		while (parent) {
 			parent.leaves = parent.leaves ? (parent.leaves + 1) : 1;
@@ -102,7 +106,7 @@
 				}
 				buildTree(cat.categories, out, options, cat, depth + 1);
 			} else {
-				addLeaf(out, cat, parent);
+				addLeaf(out, cat, parent, options.reverseTooltipTitle);
 			}
 		}
 		options.depth = mathMax(options.depth, depth);
@@ -164,8 +168,11 @@
 			reverseTree = [],
 			stats = {},
 			labelOptions = this.options.labels,
+			tooltipOptions = this.chart.options.tooltip,
 			userAttr = labelOptions.groupedOptions,
 			css = labelOptions.style;
+
+		stats.reverseTooltipTitle = tooltipOptions.reverseTitle || false;
 
 		// build categories tree
 		buildTree(categories, reverseTree, stats);


### PR DESCRIPTION
- Setting the new reverseTitle option on the chart.tooltip object will result in the tooltip title being displayed as <high_level_category>, <middle_level_category>, <low_level_category> rather than the default low to high order

- If the option is omitted, it defaults to false

Let me know if there are other preferences on the option name or how it is obtained