### PR TITLE
fixes issue with autoRotation (works as it is before HC update).

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -388,6 +388,9 @@
 				value: category.name,
 				pos: tick.pos
 			}));
+
+			//update with new text length, since textSetter removes the size caches when text changes. #137
+			tick.label.textPxLength = tick.label.getBBox().width;
 		}
 		
 		// create elements for parent categories


### PR DESCRIPTION
Fixes issue #137 

with HC upgrade, label svgElement textSetter is removing cached text size while setting the text property. which is making textPxLength "undefined" while Highcharts trying to identify the need for autoRotation, since there is no valid textPxLength autoRotation is not being applied.