### PR TITLE
bug fix: label rotation not working at +90 and -90 deg.

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -143,6 +143,10 @@
 		}
 	}
 
+	function textPxLength(label) {
+		return Math.abs(label.rotation) === 90 ? label.getBBox().height : label.getBBox().width;
+	}
+
 	//
 	// Axis prototype
 	//
@@ -390,7 +394,7 @@
 			}));
 
 			//update with new text length, since textSetter removes the size caches when text changes. #137
-			tick.label.textPxLength = tick.label.getBBox().width;
+			tick.label.textPxLength = textPxLength(tick.label);
 		}
 		
 		// create elements for parent categories


### PR DESCRIPTION
textPxLength is taken based on label orientation, fixes issues with autoRotation and rotation at 90 and -90 deg.

while rendering axis, labels are initially created horizontally and moved and rotated at the later stages in which autoRotation and rotation for 90 deg is failing to apply due to invalid textPxLength, which is previously taken from label width.