### PR TITLE
Fixes #212 ensure no label is added unless isGrouped

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -412,7 +412,7 @@
 		
 		protoTickAddLabel.call(tick);
 		
-		if (!axis.categories || !(category = axis.categories[tick.pos])) {
+		if (!axis.categories || !axis.isGrouped || !(category = axis.categories[tick.pos])) {
 			return false;
 		}
 		


### PR DESCRIPTION
This resolves #212 by ensuring only the "original" highcharts `addLabel` logic is called when `isGrouped === false` 