### PR TITLE
Fix factory function not working in nodejs environment

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -1,6 +1,7 @@
 /* global Highcharts module */
 (function (factory) {
 	if (typeof module === 'object' && module.exports) {
+		factory.default = factory;
 		module.exports = factory;
 	} else {
 		factory(Highcharts);


### PR DESCRIPTION
This library is currently not working on a NodeJs environment. 
This leads to the issue that Jest Tests will fail, because Jest is running on NodeJs. 
A workaround to get tests on components running where this Library is used, is to completely mock this library. But to find the root cause, why the tests failed and to implement a workaround therefore took me some hours. 

The error you get when running this library on a node environment is that the default function is not available. 
I checked how other libraries are implemented and found that the factory function needs to be assigned to the "default" property. 
Same as here: [https://github.com/blacklabel/custom_events/blob/master/js/customEvents.js](https://github.com/blacklabel/custom_events/blob/master/js/customEvents.js)

If you could merge this PR this would probably help other Devs to save some time and not running into this issue.