### PR TITLE
Version bump to 1.3.4 - Type definition support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Go to project page to see this module in action: [http://blacklabel.github.io/gr
 * For Highcharts version `>= 9.1.0` the plugin needs to be in version `>= 1.2.0`
 * For Highcharts version `>= 10.0.0` the plugin needs to be in version `>= 1.3.0`
 * For Highcharts version `>= 11.0.0` the plugin needs to be in version `>= 1.3.1`
-* For Highcharts version `>= 11.1.0` the plugin needs to be in version `>= 1.3.3`
+* For Highcharts version `>= 11.1.0` the plugin needs to be in version `>= 1.3.4`
 
 ### Installation
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-grouped-categories",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "homepage": "http://blacklabel.github.io/grouped_categories/",
   "authors": [
     "Sebastian Bochan <sebastian@blacklabel.pl>",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Grouped-Categories",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"title": "Grouped Categories",
 	"author": {
 		"name": "Black Label",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-grouped-categories",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Highcharts plugin to add grouped categories to charts.",
   "main": "grouped-categories.js",
   "types": "grouped-categories.d.ts",


### PR DESCRIPTION
As part of this PR -> https://github.com/blacklabel/grouped_categories/pull/235
TS type definition support is added. So, raising this PR to bump up the version from 1.3.3 to 1.3.4. So everyone can consume this and get rid of TS workaround.

@pawelfus Request you to approve and release a new tag -> 1.3.4 
Thanks in advance!