### PR TITLE
Vertical centering for x-axis label for grouped axes

### DIFF
--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -221,15 +221,6 @@
 				mergedCSS = hasOptions && userAttr[i - 1].style ? merge(css, userAttr[i - 1].style) : css;
 			this.groupFontHeights[i] = Math.round(fontMetrics(mergedCSS ? mergedCSS.fontSize : 0).b * 0.3);
 		}
-
-		// Reduce default distance to 40% for grouped axes to center leaf labels vertically.
-        if (this.isGrouped && !this._gcDistanceAdjusted) {
-            var userLabels = options.labels;
-            if (!userLabels || userLabels.distance == null) {
-                this.options.labels.distance = this.options.labels.distance * 0.4;
-            }
-            this._gcDistanceAdjusted = true;
-        }
 	};
 
 
@@ -651,7 +642,9 @@
 	tickProto.getLabelSize = function () {
 		if (this.axis.isGrouped === true) {
 			// #72, getBBox might need recalculating when chart is tall
-			var size = protoTickGetLabelSize.call(this) + 10;
+			// Include labels.distance in the leaf grid height.
+			var distance = pick(this.axis.options.labels && this.axis.options.labels.distance, 0),
+				size = protoTickGetLabelSize.call(this) + 10 + Math.max(0, distance);
 			if (this.axis.topLabelSize < size) {
 				this.axis.topLabelSize = this.axis.labelsSizes[0];
 				this.axis.labelsSizes[0] = size;

--- a/grouped-categories.js
+++ b/grouped-categories.js
@@ -221,6 +221,15 @@
 				mergedCSS = hasOptions && userAttr[i - 1].style ? merge(css, userAttr[i - 1].style) : css;
 			this.groupFontHeights[i] = Math.round(fontMetrics(mergedCSS ? mergedCSS.fontSize : 0).b * 0.3);
 		}
+
+		// Reduce default distance to 40% for grouped axes to center leaf labels vertically.
+        if (this.isGrouped && !this._gcDistanceAdjusted) {
+            var userLabels = options.labels;
+            if (!userLabels || userLabels.distance == null) {
+                this.options.labels.distance = this.options.labels.distance * 0.4;
+            }
+            this._gcDistanceAdjusted = true;
+        }
 	};
 
 


### PR DESCRIPTION
This reduces the gap between the leaf labels and the plot area for grouped axes.

- `this.options.labels.distance` controls the pixel spacing between tick labels and the axis line. Highcharts defaults this to a value that works for flat (non-grouped) categories.
- With grouped categories, that default gap is too large — leaf labels sit too far from the chart, leaving excessive whitespace above the parent label rows.
- Multiplying by `0.4` shrinks it to 40% of the default, pulling leaf labels closer to the plot area.
- `userLabels.distance == null` ensures it only applies when the user **hasn't** explicitly set a custom distance — respecting user config.
- `_gcDistanceAdjusted` is a one-time flag preventing the reduction from compounding on repeated `setupGroups` calls (e.g., `setCategories`).

**Before fix:**
https://github.com/user-attachments/assets/cc3760db-bb94-47fa-b59d-6c8b6f5da094

**After fix:**
https://github.com/user-attachments/assets/97e80eba-c9aa-4312-bbae-3c91ce6d1690


